### PR TITLE
feat: implement kernel heap allocator (kmalloc/kfree)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ MMAP_SRC = src/mem/mmap.c
 PMM_SRC = src/mem/pmm.c
 VMM_SRC = src/mem/vmm.c
 VMM_FLUSH_SRC = src/arch/x86/vmm_flush.asm
+KMALLOC_SRC = src/mem/kmalloc.c
 
 # Object files
 BOOT_OBJ = $(BUILD_DIR)/boot.o
@@ -49,9 +50,10 @@ MMAP_OBJ = $(BUILD_DIR)/mmap.o
 PMM_OBJ = $(BUILD_DIR)/pmm.o
 VMM_OBJ = $(BUILD_DIR)/vmm.o
 VMM_FLUSH_OBJ = $(BUILD_DIR)/vmm_flush.o
+KMALLOC_OBJ = $(BUILD_DIR)/kmalloc.o
 
 # All object files
-OBJS = $(BOOT_OBJ) $(KERNEL_OBJ) $(VIDEO_OBJ) $(FONT_OBJ) $(CONSOLE_OBJ) $(GDT_OBJ) $(GDT_FLUSH_OBJ) $(IDT_OBJ) $(IDT_FLUSH_OBJ) $(ISR_OBJ) $(IRQ_OBJ) $(MMAP_OBJ) $(PMM_OBJ) $(VMM_OBJ) $(VMM_FLUSH_OBJ)
+OBJS = $(BOOT_OBJ) $(KERNEL_OBJ) $(VIDEO_OBJ) $(FONT_OBJ) $(CONSOLE_OBJ) $(GDT_OBJ) $(GDT_FLUSH_OBJ) $(IDT_OBJ) $(IDT_FLUSH_OBJ) $(ISR_OBJ) $(IRQ_OBJ) $(MMAP_OBJ) $(PMM_OBJ) $(VMM_OBJ) $(VMM_FLUSH_OBJ) $(KMALLOC_OBJ)
 
 # Output files
 KERNEL_ELF = $(BUILD_DIR)/kernel.elf
@@ -176,6 +178,12 @@ $(VMM_FLUSH_OBJ): $(VMM_FLUSH_SRC)
 	@mkdir -p $(BUILD_DIR)
 	@echo "Compiling VMM flush..."
 	$(NASM) $(NASMFLAGS) $(VMM_FLUSH_SRC) -o $(VMM_FLUSH_OBJ)
+
+# Compile KMALLOC
+$(KMALLOC_OBJ): $(KMALLOC_SRC)
+	@mkdir -p $(BUILD_DIR)
+	@echo "Compiling KMALLOC..."
+	$(CC) $(CFLAGS) -c $(KMALLOC_SRC) -o $(KMALLOC_OBJ)
 
 # Clean build artifacts
 clean:

--- a/include/mem/kmalloc.h
+++ b/include/mem/kmalloc.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+// 커널 힙 할당자 초기화
+void kmalloc_init(void);
+
+// 메모리 할당 (size 바이트)
+void* kmalloc(size_t size);
+
+// 메모리 해제 (성공: true, 실패: false)
+bool kfree(void* ptr);
+
+// 통계 정보 (모두 헤더 제외한 데이터 크기)
+uint32_t kmalloc_used_bytes(void);   // 할당된 데이터 크기
+uint32_t kmalloc_free_bytes(void);   // 사용 가능한 데이터 크기
+uint32_t kmalloc_total_bytes(void);  // 전체 힙 크기 (헤더 포함)

--- a/include/mem/pmm.h
+++ b/include/mem/pmm.h
@@ -1,13 +1,18 @@
 #pragma once
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #define PAGE_SIZE 4096u
 
 void pmm_init(uint32_t magic, void* mbinfo);
 void* pmm_alloc_page(void);
-void pmm_free_page(void* page);
+bool pmm_free_page(void* page);
+
+// 연속된 페이지 할당/해제
+void* pmm_alloc_pages(uint32_t count);
+bool pmm_free_pages_range(void* page, uint32_t count);
 
 uint32_t pmm_total_pages(void);
-uint32_t pmm_free_pages(void);
+uint32_t pmm_get_free_pages(void);
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,7 @@
 #include "mem/mmap.h"
 #include "mem/pmm.h"
 #include "mem/vmm.h"
+#include "mem/kmalloc.h"
 #include "arch/x86/gdt.h"
 #include "arch/x86/idt.h"
 
@@ -60,7 +61,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
     if (page1 && page2 && page3) {
         console_puts("[PMM] Allocated 3 pages successfully\n");
         console_puts("[PMM] Free pages after allocation: ");
-        console_putu32(pmm_free_pages());
+        console_putu32(pmm_get_free_pages());
         console_puts("\n");
         
         pmm_free_page(page1);
@@ -69,7 +70,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         
         console_puts("[PMM] Freed 3 pages\n");
         console_puts("[PMM] Free pages after free: ");
-        console_putu32(pmm_free_pages());
+        console_putu32(pmm_get_free_pages());
         console_puts("\n");
     } else {
         console_puts("[PMM] Failed to allocate pages\n");
@@ -101,8 +102,117 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         pmm_free_page(test_phys);
     }
     
+    // Initialize KMALLOC
+    console_puts("\n[KMALLOC] Initializing kernel heap...\n");
+    kmalloc_init();
+    
+    // Test: kmalloc and kfree
+    console_puts("[KMALLOC] Testing memory allocation...\n");
+    
+    // 작은 할당 테스트
+    char* str1 = (char*)kmalloc(32);
+    if (str1) {
+        console_puts("[KMALLOC] Allocated 32 bytes\n");
+        console_puts("[KMALLOC] Used: ");
+        console_putu32(kmalloc_used_bytes());
+        console_puts(" bytes\n");
+        
+        // 메모리에 데이터 쓰기
+        for (int i = 0; i < 31; i++) {
+            str1[i] = 'A' + (i % 26);
+        }
+        str1[31] = '\0';
+        
+        console_puts("[KMALLOC] Written data: ");
+        console_puts(str1);
+        console_puts("\n");
+    }
+    
+    // 중간 크기 할당 테스트
+    int* numbers = (int*)kmalloc(10 * sizeof(int));
+    if (numbers) {
+        console_puts("[KMALLOC] Allocated array of 10 integers\n");
+        console_puts("[KMALLOC] Used: ");
+        console_putu32(kmalloc_used_bytes());
+        console_puts(" bytes\n");
+        
+        // 배열에 데이터 쓰기
+        for (int i = 0; i < 10; i++) {
+            numbers[i] = i * 100;
+        }
+        
+        console_puts("[KMALLOC] Array values: ");
+        for (int i = 0; i < 10; i++) {
+            console_putu32(numbers[i]);
+            console_puts(" ");
+        }
+        console_puts("\n");
+    }
+    
+    // 큰 할당 테스트
+    void* big_block = kmalloc(8192);
+    if (big_block) {
+        console_puts("[KMALLOC] Allocated 8192 bytes\n");
+        console_puts("[KMALLOC] Used: ");
+        console_putu32(kmalloc_used_bytes());
+        console_puts(" bytes\n");
+    }
+    
+    // 해제 테스트
+    console_puts("[KMALLOC] Testing kfree...\n");
+    if (kfree(str1)) {
+        console_puts("[KMALLOC] Freed str1 successfully\n");
+    }
+    if (kfree(numbers)) {
+        console_puts("[KMALLOC] Freed numbers successfully\n");
+    }
+    if (kfree(big_block)) {
+        console_puts("[KMALLOC] Freed big_block successfully\n");
+    }
+    
+    console_puts("[KMALLOC] After free - Used: ");
+    console_putu32(kmalloc_used_bytes());
+    console_puts(" bytes, Free: ");
+    console_putu32(kmalloc_free_bytes());
+    console_puts(" bytes\n");
+    
+    // Double free 테스트
+    console_puts("[KMALLOC] Testing double free detection...\n");
+    if (!kfree(str1)) {
+        console_puts("[KMALLOC] Double free correctly detected\n");
+    }
+    
+    // 병합 테스트: 연속된 블록 할당 후 순서대로 해제
+    console_puts("\n[KMALLOC] Testing block merging...\n");
+    void* block1 = kmalloc(64);
+    void* block2 = kmalloc(64);
+    void* block3 = kmalloc(64);
+    
+    if (block1 && block2 && block3) {
+        console_puts("[KMALLOC] Allocated 3 blocks (64 bytes each)\n");
+        console_puts("[KMALLOC] Used: ");
+        console_putu32(kmalloc_used_bytes());
+        console_puts(" bytes\n");
+        
+        // 중간 블록 먼저 해제
+        kfree(block2);
+        console_puts("[KMALLOC] Freed middle block\n");
+        
+        // 첫 번째 블록 해제 (앞과 병합되어야 함)
+        kfree(block1);
+        console_puts("[KMALLOC] Freed first block (should merge with middle)\n");
+        
+        // 마지막 블록 해제 (모두 병합되어야 함)
+        kfree(block3);
+        console_puts("[KMALLOC] Freed last block (should merge all)\n");
+        
+        console_puts("[KMALLOC] After merging - Free: ");
+        console_putu32(kmalloc_free_bytes());
+        console_puts(" bytes\n");
+    }
+    
     // Test: Put string
-    console_puts("Hello World!\n");
+    console_puts("\nHello World!\n");
     console_puts("Console test: ");
     console_putc('O');
     console_putc('K');

--- a/src/mem/kmalloc.c
+++ b/src/mem/kmalloc.c
@@ -1,0 +1,252 @@
+#include "mem/kmalloc.h"
+#include "mem/pmm.h"
+#include "drivers/console/console.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+// 블록 헤더 구조체
+typedef struct block_header {
+    size_t size;                    // 블록 크기 (헤더 제외, 사용자가 사용 가능한 크기)
+    bool is_free;                   // 할당 여부
+    struct block_header* next;      // 다음 블록
+    struct block_header* prev;      // 이전 블록
+    uint32_t magic;                 // 매직 넘버 (오버플로우 감지)
+} block_header_t;
+
+#define BLOCK_MAGIC 0xDEADBEEF
+#define HEADER_SIZE sizeof(block_header_t)
+#define ALIGN_SIZE 16
+#define MIN_BLOCK_SIZE 32
+
+// 힙 관리 변수
+static block_header_t* heap_start = NULL;
+static block_header_t* heap_end = NULL;
+static uint32_t total_heap_size = 0;  // 전체 힙 크기 (헤더 포함)
+static uint32_t used_bytes = 0;       // 할당된 데이터 크기 (헤더 제외)
+static uint32_t free_bytes = 0;       // 사용 가능한 데이터 크기 (헤더 제외)
+
+// 크기를 정렬
+static inline size_t align_size(size_t size) {
+    return (size + ALIGN_SIZE - 1) & ~(ALIGN_SIZE - 1);
+}
+
+// 새로운 페이지를 힙에 추가
+// pmm_alloc_pages는 원자적으로 동작하므로 부분 할당 없음
+static bool expand_heap(size_t min_size) {
+    // 필요한 페이지 수 계산
+    size_t needed = min_size + HEADER_SIZE;
+    uint32_t pages_needed = (needed + PAGE_SIZE - 1) / PAGE_SIZE;
+    
+    // 연속된 페이지 할당 (원자적: 모두 성공 or 모두 실패)
+    // 부분 할당으로 인한 메모리 누수 없음
+    void* new_pages = pmm_alloc_pages(pages_needed);
+    if (!new_pages) {
+        console_puts("[KMALLOC] Failed to allocate ");
+        // 간단한 숫자 출력
+        uint32_t pn = pages_needed;
+        char buf[12];
+        int idx = 0;
+        while (pn > 0 && idx < 11) {
+            buf[idx++] = (char)('0' + (pn % 10));
+            pn /= 10;
+        }
+        while (idx--) console_putc(buf[idx]);
+        console_puts(" contiguous pages\n");
+        return false;
+    }
+    
+    block_header_t* new_block = (block_header_t*)new_pages;
+    size_t block_size = pages_needed * PAGE_SIZE - HEADER_SIZE;
+    
+    new_block->size = block_size;
+    new_block->is_free = true;
+    new_block->next = NULL;
+    new_block->prev = heap_end;
+    new_block->magic = BLOCK_MAGIC;
+    
+    if (heap_end) {
+        heap_end->next = new_block;
+    }
+    
+    heap_end = new_block;
+    
+    if (!heap_start) {
+        heap_start = new_block;
+    }
+    
+    total_heap_size += pages_needed * PAGE_SIZE;
+    free_bytes += block_size;
+    
+    return true;
+}
+
+// 블록 분할
+// 주의: free_bytes는 호출자가 관리해야 함 (이 함수는 블록 구조만 변경)
+static void split_block(block_header_t* block, size_t size) {
+    if (block->size < size + HEADER_SIZE + MIN_BLOCK_SIZE) {
+        // 분할할 만큼 크지 않음
+        return;
+    }
+    
+    size_t old_size = block->size;
+    
+    // 새 블록 생성 (남는 부분)
+    block_header_t* new_block = (block_header_t*)((uint8_t*)block + HEADER_SIZE + size);
+    new_block->size = old_size - size - HEADER_SIZE;
+    new_block->is_free = true;
+    new_block->next = block->next;
+    new_block->prev = block;
+    new_block->magic = BLOCK_MAGIC;
+    
+    if (block->next) {
+        block->next->prev = new_block;
+    } else {
+        heap_end = new_block;
+    }
+    
+    block->next = new_block;
+    block->size = size;
+    
+    // 분할 후 free_bytes 조정 필요 없음:
+    // - 원래 블록 전체가 free였고
+    // - 분할 후에도 (사용 부분 + 헤더 + 남는 free 부분) = 원래 크기
+    // - 호출자(kmalloc)가 사용 부분을 free_bytes에서 뺄 것임
+}
+
+// 인접한 free 블록 병합
+// 앞뒤로 연속된 모든 free 블록을 병합
+static void merge_free_blocks(block_header_t* block) {
+    if (!block || !block->is_free) {
+        return;
+    }
+    
+    // 1단계: 이전 블록들과 병합 (뒤로 이동하면서)
+    // block->prev가 free면 block을 prev로 이동
+    while (block->prev && block->prev->is_free) {
+        block = block->prev;
+    }
+    
+    // 2단계: 현재 위치(가장 앞)에서 다음 블록들과 병합
+    while (block->next && block->next->is_free) {
+        block_header_t* next_block = block->next;
+        
+        // 다음 블록을 현재 블록에 병합
+        block->size += HEADER_SIZE + next_block->size;
+        block->next = next_block->next;
+        
+        if (block->next) {
+            block->next->prev = block;
+        } else {
+            heap_end = block;
+        }
+    }
+}
+
+void kmalloc_init(void) {
+    console_puts("[KMALLOC] Initializing kernel heap allocator...\n");
+    
+    heap_start = NULL;
+    heap_end = NULL;
+    total_heap_size = 0;
+    used_bytes = 0;
+    free_bytes = 0;
+    
+    // 초기 힙 크기: 4 페이지 (16KB)
+    if (!expand_heap(4 * PAGE_SIZE)) {
+        console_puts("[KMALLOC] Failed to initialize heap\n");
+        return;
+    }
+    
+    console_puts("[KMALLOC] Heap initialized\n");
+}
+
+void* kmalloc(size_t size) {
+    if (size == 0) {
+        return NULL;
+    }
+    
+    // 크기 정렬
+    size = align_size(size);
+    
+    // 재귀 대신 루프 사용 (커널에서 재귀는 스택 오버플로우 위험)
+    while (1) {
+        // First-fit 알고리즘으로 적합한 블록 찾기
+        block_header_t* current = heap_start;
+        while (current) {
+            if (current->is_free && current->size >= size) {
+                // 적합한 블록 발견
+                size_t old_free_size = current->size;
+                
+                // 블록 분할 (가능하면)
+                split_block(current, size);
+                // 분할 후 current->size는 size로 변경됨
+                // 남는 부분은 새로운 free 블록으로 생성됨
+                
+                current->is_free = false;
+                
+                // free_bytes 업데이트:
+                // - 원래 free였던 old_free_size에서
+                // - 실제 사용하는 current->size를 뺌
+                // - 분할로 생긴 남는 블록은 여전히 free이므로 자동으로 반영됨
+                used_bytes += current->size;
+                free_bytes -= current->size;
+                
+                // 데이터 영역 반환 (헤더 다음)
+                return (void*)((uint8_t*)current + HEADER_SIZE);
+            }
+            current = current->next;
+        }
+        
+        // 적합한 블록이 없으면 힙 확장
+        if (!expand_heap(size)) {
+            console_puts("[KMALLOC] Out of memory\n");
+            return NULL;
+        }
+        
+        // 힙 확장 성공, 다시 루프 시작하여 블록 찾기
+    }
+}
+
+bool kfree(void* ptr) {
+    if (!ptr) {
+        return false;
+    }
+    
+    // 헤더 위치 계산
+    block_header_t* block = (block_header_t*)((uint8_t*)ptr - HEADER_SIZE);
+    
+    // 매직 넘버 검증
+    if (block->magic != BLOCK_MAGIC) {
+        console_puts("[KFREE] Invalid magic number - corrupted block\n");
+        return false;
+    }
+    
+    // 이미 free된 블록인지 확인 (double free 방지)
+    if (block->is_free) {
+        console_puts("[KFREE] Double free detected\n");
+        return false;
+    }
+    
+    // 블록 해제
+    block->is_free = true;
+    used_bytes -= block->size;
+    free_bytes += block->size;
+    
+    // 인접 블록 병합
+    merge_free_blocks(block);
+    
+    return true;
+}
+
+uint32_t kmalloc_used_bytes(void) {
+    return used_bytes;
+}
+
+uint32_t kmalloc_free_bytes(void) {
+    return free_bytes;
+}
+
+uint32_t kmalloc_total_bytes(void) {
+    return total_heap_size;
+}

--- a/src/mem/pmm.c
+++ b/src/mem/pmm.c
@@ -334,40 +334,122 @@ void* pmm_alloc_page(void) {
     return NULL;
 }
 
-void pmm_free_page(void* page) {
+bool pmm_free_page(void* page) {
     if (!bitmap || !page) {
-        return;
+        return false;
     }
 
     uint64_t page_addr = (uint64_t)page;
     
     if (page_addr < memory_start || page_addr >= memory_end) {
-        return;
+        return false;
     }
 
     if ((page_addr & 0xFFF) != 0) {
-        return;
+        return false;
     }
 
     uint32_t page_offset = (uint32_t)(page_addr - memory_start);
     uint32_t page_idx = page_offset >> 12;
     
     if (page_idx >= total_pages) {
-        return;
+        return false;
     }
 
     if (!bitmap_get(page_idx)) {
-        return;
+        return false;
     }
 
     bitmap_clear(page_idx);
     free_pages++;
+    return true;
+}
+
+// 연속된 count개의 페이지 할당
+// 원자적(atomic) 동작: 모두 할당 가능하면 할당, 아니면 NULL 반환
+// 부분 할당 없음 - 메모리 누수 방지
+void* pmm_alloc_pages(uint32_t count) {
+    if (!bitmap || free_pages < count || count == 0) {
+        return NULL;
+    }
+
+    // 1단계: 연속된 free 페이지 찾기 (할당하지 않음)
+    uint32_t consecutive = 0;
+    uint32_t start_idx = 0;
+    bool found = false;
+    
+    for (uint32_t i = 0; i < total_pages; i++) {
+        if (!bitmap_get(i)) {
+            if (consecutive == 0) {
+                start_idx = i;
+            }
+            consecutive++;
+            
+            if (consecutive == count) {
+                found = true;
+                break;
+            }
+        } else {
+            consecutive = 0;
+        }
+    }
+
+    if (!found) {
+        return NULL;
+    }
+
+    // 2단계: 연속된 페이지 발견 후 모두 할당 (원자적)
+    for (uint32_t j = 0; j < count; j++) {
+        bitmap_set(start_idx + j);
+    }
+    free_pages -= count;
+    
+    return (void*)(memory_start + (uint64_t)start_idx * PAGE_SIZE);
+}
+
+// 연속된 count개의 페이지 해제
+bool pmm_free_pages_range(void* page, uint32_t count) {
+    if (!bitmap || !page || count == 0) {
+        return false;
+    }
+
+    uint64_t page_addr = (uint64_t)page;
+    
+    if (page_addr < memory_start || page_addr >= memory_end) {
+        return false;
+    }
+
+    if ((page_addr & 0xFFF) != 0) {
+        return false;
+    }
+
+    uint32_t page_offset = (uint32_t)(page_addr - memory_start);
+    uint32_t start_idx = page_offset >> 12;
+    
+    if (start_idx + count > total_pages) {
+        return false;
+    }
+
+    // 모든 페이지가 할당된 상태인지 확인
+    for (uint32_t i = 0; i < count; i++) {
+        if (!bitmap_get(start_idx + i)) {
+            return false;  // 이미 free된 페이지 포함
+        }
+    }
+
+    // 모두 해제
+    for (uint32_t i = 0; i < count; i++) {
+        bitmap_clear(start_idx + i);
+    }
+    free_pages += count;
+    
+    return true;
 }
 
 uint32_t pmm_total_pages(void) {
     return total_pages;
 }
 
-uint32_t pmm_free_pages(void) {
+uint32_t pmm_get_free_pages(void) {
     return free_pages;
 }


### PR DESCRIPTION
related #12

# 개발 내용

## kmalloc/kfree 구현
- 블록 기반 힙 할당자 구현
- First-fit 알고리즘 사용
- 블록 분할 및 병합 지원
- 16바이트 정렬

## PMM 개선
- `pmm_alloc_pages()`: 연속된 페이지 할당 (원자적 동작)
- `pmm_free_pages_range()`: 연속된 페이지 해제
- `pmm_get_free_pages()`: 함수 이름 충돌 해결

## 안전성 개선
- 원자적 페이지 할당: 부분 할당으로 인한 메모리 누수 방지
- 재귀 제거: while 루프로 변경하여 스택 오버플로우 방지
- Double free 감지
- 매직 넘버를 통한 메모리 오염 감지
- 강건한 블록 병합: 연속된 모든 free 블록 완전 병합

## 메모리 통계
- `kmalloc_used_bytes()`: 할당된 데이터 크기
- `kmalloc_free_bytes()`: 사용 가능한 데이터 크기
- `kmalloc_total_bytes()`: 전체 힙 크기

## 테스트
- 다양한 크기 할당 테스트 (32 bytes, 배열, 8KB)
- 메모리 해제 테스트
- Double free 감지 테스트
- 블록 병합 테스트 (연속된 3개 블록 해제)

Made with [Cursor](https://cursor.com)