### PR TITLE
feat: clean up terminated scheduler tasks

### DIFF
--- a/include/process/scheduler.h
+++ b/include/process/scheduler.h
@@ -27,6 +27,7 @@ void scheduler_remove_task(task_struct_t* task);
 // 스케줄러 통계
 uint32_t scheduler_get_total_tasks(void);
 void scheduler_print_status(void);
+void scheduler_reap_terminated_tasks(void);
 
 // ✅ IRQ 기반 스케줄러 핸들러
 // 인터럽트 프레임 구조체는 scheduler.c에 정의됨

--- a/include/process/task.h
+++ b/include/process/task.h
@@ -37,6 +37,7 @@ typedef struct task_struct {
 void task_init(void);
 task_struct_t* task_create(const char* name, void (*entry_point)(void), uint32_t priority);
 void task_destroy(task_struct_t* task);
+void task_exit(void) __attribute__((noreturn));
 task_struct_t* task_get_current(void);
 void task_set_current(task_struct_t* task);
 uint32_t task_get_next_pid(void);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -15,6 +15,13 @@ static void hlt_loop(void) {
     for(;;) __asm__ __volatile__("hlt");
 }
 
+static void kernel_idle_loop(void) {
+    for (;;) {
+        scheduler_reap_terminated_tasks();
+        __asm__ __volatile__("sti; hlt");
+    }
+}
+
 static void console_putu32(uint32_t v) {
     char buf[11];
     int idx = 0;
@@ -279,7 +286,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         console_puts("[SCHEDULER] Output should cycle through 1, 2, and 3.\n");
 
         idt_enable_interrupts();
-        hlt_loop();
+        kernel_idle_loop();
     }
     
     // Test: Put string

--- a/src/process/scheduler.c
+++ b/src/process/scheduler.c
@@ -1,5 +1,6 @@
 #include "process/scheduler.h"
 #include "process/task.h"
+#include "arch/x86/idt.h"
 #include "drivers/console/console.h"
 #include <stddef.h>
 
@@ -16,8 +17,11 @@ struct interrupt_frame {
 // 라운드 로빈 큐
 static task_struct_t* ready_queue_head = NULL;
 static task_struct_t* ready_queue_tail = NULL;
+static task_struct_t* terminated_queue_head = NULL;
+static task_struct_t* terminated_queue_tail = NULL;
 static task_struct_t* current_task = NULL;
 static uint32_t total_tasks = 0;
+static uint32_t terminated_tasks = 0;
 static uint32_t scheduler_ticks = 0;
 
 static void scheduler_enqueue_task(task_struct_t* task) {
@@ -57,12 +61,56 @@ static task_struct_t* scheduler_dequeue_task(void) {
     return task;
 }
 
+static void scheduler_enqueue_terminated_task(task_struct_t* task) {
+    if (!task || task->pid == 0) {
+        return;
+    }
+
+    task->next = NULL;
+    task->prev = terminated_queue_tail;
+
+    if (terminated_queue_tail) {
+        terminated_queue_tail->next = task;
+    } else {
+        terminated_queue_head = task;
+    }
+
+    terminated_queue_tail = task;
+    terminated_tasks++;
+}
+
+static task_struct_t* scheduler_dequeue_terminated_task(void) {
+    task_struct_t* task = terminated_queue_head;
+    if (!task) {
+        return NULL;
+    }
+
+    terminated_queue_head = task->next;
+    if (terminated_queue_head) {
+        terminated_queue_head->prev = NULL;
+    } else {
+        terminated_queue_tail = NULL;
+    }
+
+    task->next = NULL;
+    task->prev = NULL;
+
+    if (terminated_tasks > 0) {
+        terminated_tasks--;
+    }
+
+    return task;
+}
+
 void scheduler_init(void) {
     console_puts("[SCHEDULER] Initializing round-robin scheduler...\n");
     
     ready_queue_head = NULL;
     ready_queue_tail = NULL;
+    terminated_queue_head = NULL;
+    terminated_queue_tail = NULL;
     total_tasks = 0;
+    terminated_tasks = 0;
     scheduler_ticks = 0;
     
     // 현재 태스크는 커널 태스크
@@ -154,6 +202,20 @@ uint32_t scheduler_get_total_tasks(void) {
     return total_tasks;
 }
 
+void scheduler_reap_terminated_tasks(void) {
+    for (;;) {
+        idt_disable_interrupts();
+        task_struct_t* task = scheduler_dequeue_terminated_task();
+        idt_enable_interrupts();
+
+        if (!task) {
+            return;
+        }
+
+        task_destroy(task);
+    }
+}
+
 void scheduler_print_status(void) {
     console_puts("[SCHEDULER] Status:\n");
     console_puts("  Total tasks in ready queue: ");
@@ -196,6 +258,20 @@ void scheduler_print_status(void) {
     
     console_puts("  Scheduler ticks: ");
     count = scheduler_ticks;
+    idx = 0;
+    if (count == 0) {
+        console_putc('0');
+    } else {
+        while (count > 0 && idx < 11) {
+            buf[idx++] = (char)('0' + (count % 10));
+            count /= 10;
+        }
+        while (idx--) console_putc(buf[idx]);
+    }
+    console_puts("\n");
+
+    console_puts("  Terminated tasks pending cleanup: ");
+    count = terminated_tasks;
     idx = 0;
     if (count == 0) {
         console_putc('0');
@@ -272,6 +348,8 @@ uint32_t scheduler_irq_handler(void* frame_ptr) {
             if (old_task->pid != 0) {
                 scheduler_enqueue_task(old_task);
             }
+        } else if (old_task->state == TASK_TERMINATED) {
+            scheduler_enqueue_terminated_task(old_task);
         }
         
         // 다음 태스크 선택

--- a/src/process/task.c
+++ b/src/process/task.c
@@ -23,14 +23,7 @@ static void task_entry_trampoline(void) {
         current->entry_point();
     }
 
-    if (current) {
-        current->state = TASK_TERMINATED;
-        current->time_remaining = 0;
-    }
-
-    for (;;) {
-        __asm__ __volatile__("sti; hlt");
-    }
+    task_exit();
 }
 
 task_struct_t* task_get_kernel_task(void) {
@@ -68,6 +61,19 @@ void task_init(void) {
 
 uint32_t task_get_next_pid(void) {
     return next_pid++;
+}
+
+void task_exit(void) {
+    task_struct_t* current = scheduler_get_current_task();
+
+    if (current && current->pid != 0) {
+        current->state = TASK_TERMINATED;
+        current->time_remaining = 0;
+    }
+
+    for (;;) {
+        __asm__ __volatile__("sti; hlt");
+    }
 }
 
 task_struct_t* task_create(const char* name, void (*entry_point)(void), uint32_t priority) {
@@ -176,6 +182,10 @@ task_struct_t* task_create(const char* name, void (*entry_point)(void), uint32_t
 
 void task_destroy(task_struct_t* task) {
     if (!task) {
+        return;
+    }
+
+    if (task->pid == 0 || task == scheduler_get_current_task()) {
         return;
     }
     


### PR DESCRIPTION
closes #18

# 개발 내용

## task_exit 구현
- task entry 함수가 반환되면 명시적으로 `task_exit()` 호출
- 현재 task를 `TASK_TERMINATED` 상태로 전환
- 종료된 task가 잘못된 return address로 복귀하지 않도록 보호

## Scheduler cleanup 흐름 추가
- 종료된 task를 ready queue에 다시 넣지 않도록 처리
- terminated queue 추가
- kernel idle loop에서 terminated task의 kernel stack/PCB 회수

## Idle loop 개선
- scheduler demo 시작 후 kernel task가 idle loop로 진입
- ready queue가 비었을 때 idle loop가 종료 task cleanup 수행
- 기존 round-robin scheduler 출력 유지

## 테스트
- [x] `make` 빌드 성공
- [x] 변경 파일 `-Wall -Wextra` 컴파일 확인
- [x] QEMU screendump로 round-robin 출력 유지 확인
- [ ] 종료 task cleanup을 별도 finite task demo로 시각 검증

## 참고
- 기존 링커 스크립트의 `LOAD segment with RWX permissions` 경고는 이번 PR 범위 밖으로 유지됨
