### PR TITLE
feat: document canonical build flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ NASM = nasm
 CC = x86_64-elf-gcc
 LD = x86_64-elf-ld
 GRUB_MKRESCUE = i686-elf-grub-mkrescue
+QEMU = qemu-system-i386
 
 # Flags
 NASMFLAGS = -f elf32
@@ -217,6 +218,9 @@ clean:
 # Rebuild everything
 rebuild: clean all
 
-# Phony targets
-.PHONY: all clean rebuild
+# Run in QEMU
+run: $(ISO)
+	$(QEMU) -cdrom $(ISO) -no-reboot -no-shutdown
 
+# Phony targets
+.PHONY: all clean rebuild run

--- a/README.md
+++ b/README.md
@@ -3,3 +3,53 @@
 방화벽을 만들던 보안 회사 재직 시절 자체 OS를 개발하며 어깨 넘어로 배운것들에 기반하여 운영체제 deepdive 학습을 목적으로 만들고 있습니다.   
 
 POSIX 표준을 철저하게 준수하여 개발 할 예정입니다.
+
+## Build
+
+`Makefile`이 커널 빌드의 기준입니다.
+
+```bash
+make
+```
+
+빌드가 성공하면 ISO 이미지가 생성됩니다.
+
+```text
+build/archanOS.iso
+```
+
+전체를 깨끗하게 다시 빌드하려면 다음 명령을 사용합니다.
+
+```bash
+make rebuild
+```
+
+기존 `build.sh`도 같은 경로를 사용합니다.
+
+```bash
+./build.sh
+```
+
+## Run
+
+QEMU로 실행하려면 다음 중 하나를 사용합니다.
+
+```bash
+make run
+```
+
+```bash
+./run_qemu.sh
+```
+
+`run_qemu.sh`는 ISO가 없으면 먼저 `make`로 빌드한 뒤 QEMU를 실행합니다.
+
+## Toolchain
+
+현재 빌드는 다음 도구를 기대합니다.
+
+- `nasm`
+- `x86_64-elf-gcc`
+- `x86_64-elf-ld`
+- `i686-elf-grub-mkrescue`
+- `qemu-system-i386`

--- a/build.sh
+++ b/build.sh
@@ -1,34 +1,5 @@
-# /build.sh
-
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# clean
-rm -rf build
-mkdir -p build/iso/boot/grub
-
-cp res/grub.cfg build/iso/boot/grub/grub.cfg
-
-# 1) boot.asm to object
-nasm -f elf32 src/boot.asm -o build/boot.o
-
-# 2) kernel.c to object
-x86_64-elf-gcc -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx -c src/kernel.c -o build/kernel.o
-
-# 3) video.c to object
-x86_64-elf-gcc -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx -c src/drivers/video/video.c -o build/video.o
-
-# 4) font8x16.c to object
-x86_64-elf-gcc -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx -c src/font/font8x16.c -o build/font8x16.o
-
-# 5) console.c to object
-x86_64-elf-gcc -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx -c src/drivers/console/console.c -o build/console.o
-
-# 6) link 
-x86_64-elf-ld -m elf_i386 -T linker.ld -o build/kernel.elf build/boot.o build/kernel.o build/video.o build/font8x16.o build/console.o
-
-cp build/kernel.elf build/iso/boot/kernel.bin
-
-i686-elf-grub-mkrescue -o build/archanOS.iso build/iso
-
-echo "✅ build/archanOS.iso 생성 완료"
+# Keep Makefile as the single source of truth for the kernel build.
+exec make rebuild

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
-# Run the kernel in QEMU with graphical display
-qemu-system-i386 -cdrom build/archanOS.iso -no-reboot -no-shutdown
+set -euo pipefail
+
+ISO="build/archanOS.iso"
+
+if [ ! -f "$ISO" ]; then
+    echo "[run_qemu] $ISO not found. Building it with make..."
+    make
+fi
+
+exec qemu-system-i386 -cdrom "$ISO" -no-reboot -no-shutdown


### PR DESCRIPTION
closes #20

# 개발 내용

## Build flow 정리
- `Makefile`을 커널 빌드의 단일 기준으로 문서화
- `build.sh`를 수동 컴파일 스크립트에서 `make rebuild` 래퍼로 변경
- 오래된 링크 구성으로 잘못된 커널이 만들어질 가능성 제거

## 실행 경로 개선
- `make run` 타깃 추가
- `run_qemu.sh`가 ISO 누락 시 `make`로 먼저 빌드하도록 개선
- QEMU 실행 명령을 `build/archanOS.iso` 기준으로 통일

## README 문서화
- 빌드 명령 정리: `make`, `make rebuild`, `./build.sh`
- 실행 명령 정리: `make run`, `./run_qemu.sh`
- 필요한 toolchain 목록 추가

## 테스트
- [x] `bash -n build.sh`
- [x] `bash -n run_qemu.sh`
- [x] `./build.sh`로 ISO 생성 확인
- [x] `make -n run`으로 QEMU 실행 명령 확인
- [x] `git diff --check`

## 참고
- 기존 PMM pointer cast warning과 링커 `LOAD segment with RWX permissions` warning은 이번 PR 범위 밖으로 유지됨

Made with [Cursor](https://cursor.com)