### PR TITLE
fix: split kernel linker segments

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -1,6 +1,12 @@
 /* /linker.ld */
 ENTRY(_start)
 
+PHDRS {
+  text PT_LOAD FLAGS(5);
+  rodata PT_LOAD FLAGS(4);
+  data PT_LOAD FLAGS(6);
+}
+
 SECTIONS {
   . = 1M;
 
@@ -8,24 +14,28 @@ SECTIONS {
 
   .multiboot : {
     *(.multiboot)
-  }
+  } :text
 
   .text : {
     *(.text*)
-  }
+  } :text
+
+  . = ALIGN(4K);
 
   .rodata : {
     *(.rodata*)
-  }
+  } :rodata
+
+  . = ALIGN(4K);
 
   .data : {
     *(.data*)
-  }
+  } :data
 
   .bss : {
     *(COMMON)
     *(.bss*)
-  }
+  } :data
 
   kernel_end = .;
 


### PR DESCRIPTION
closes #24

# 개발 내용

## 링커 segment 권한 분리
- `PHDRS`로 text, rodata, data LOAD segment를 명시
- `.multiboot`와 `.text`는 실행/읽기, `.rodata`는 읽기 전용, `.data`와 `.bss`는 읽기/쓰기로 분리
- `.rodata`와 `.data` 시작 주소를 4KiB 경계로 정렬해 segment 권한 경계를 명확화

## 빌드 경고 제거
- 기존 `LOAD segment with RWX permissions` warning 제거
- `readelf -l` 기준 LOAD segment가 `R E`, `R`, `RW`로 분리됨 확인

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 scheduler demo 출력 유지 확인
- [x] `git diff --check`
