### PR TITLE
build: make kernel build warning-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ QEMU = qemu-system-i386
 
 # Flags
 NASMFLAGS = -f elf32
-CFLAGS = -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx
+WARNFLAGS = -Wall -Wextra
+CFLAGS = -m32 -ffreestanding -O2 -Iinclude -mno-sse -mno-sse2 -mno-mmx $(WARNFLAGS)
 LDFLAGS = -m elf_i386 -T linker.ld
 
 # Directories

--- a/src/drivers/video/video.c
+++ b/src/drivers/video/video.c
@@ -73,8 +73,8 @@ void video_draw_char(int cx, int cy, char c) {
         if (!g_fb || g_fb->framebuffer_bpp != 32)
             return;
 
-        // Check character range
-        if (c < FONT8X16_FIRST || c > FONT8X16_LAST)
+        uint32_t glyph = (uint8_t)c;
+        if (glyph >= FONT8X16_COUNT)
             return;
 
         uint32_t width  = g_fb->framebuffer_width;
@@ -92,7 +92,7 @@ void video_draw_char(int cx, int cy, char c) {
             return;
 
         // Get font data
-        const uint8_t* font_data = font8x16[c - FONT8X16_FIRST];
+        const uint8_t* font_data = font8x16[glyph - FONT8X16_FIRST];
         uint32_t color = 0xFFFFFFFF; // white
 
         // Draw font
@@ -134,7 +134,6 @@ void video_scroll_up(void) {
         uint32_t pitch  = g_fb->framebuffer_pitch;
         uint32_t* buffer = (uint32_t*)(uintptr_t)g_fb->framebuffer_addr;
         uint32_t line_height = FONT8X16_HEIGHT;
-        uint32_t chars_per_line = width / FONT8X16_WIDTH;
         uint32_t lines_per_screen = height / line_height;
 
         // Copy lines 1 to (lines_per_screen-1) to lines 0 to (lines_per_screen-2)

--- a/src/mem/kmalloc.c
+++ b/src/mem/kmalloc.c
@@ -175,9 +175,6 @@ void* kmalloc(size_t size) {
         block_header_t* current = heap_start;
         while (current) {
             if (current->is_free && current->size >= size) {
-                // 적합한 블록 발견
-                size_t old_free_size = current->size;
-                
                 // 블록 분할 (가능하면)
                 split_block(current, size);
                 // 분할 후 current->size는 size로 변경됨
@@ -186,7 +183,6 @@ void* kmalloc(size_t size) {
                 current->is_free = false;
                 
                 // free_bytes 업데이트:
-                // - 원래 free였던 old_free_size에서
                 // - 실제 사용하는 current->size를 뺌
                 // - 분할로 생긴 남는 블록은 여전히 free이므로 자동으로 반영됨
                 used_bytes += current->size;

--- a/src/mem/vmm.c
+++ b/src/mem/vmm.c
@@ -257,7 +257,6 @@ void vmm_init(void) {
     console_puts("[VMM] Creating identity mapping for first 16MB...\n");
     
     uint32_t identity_pages = 4096; // 16MB / 4KB = 4096 pages
-    uint32_t mapped_count = 0;
     uint32_t failed_count = 0;
     
     for (uint32_t i = 0; i < identity_pages; i++) {
@@ -273,8 +272,6 @@ void vmm_init(void) {
         
         if (!vmm_map_page(page_dir, virt_addr, phys_addr, flags)) {
             failed_count++;
-        } else {
-            mapped_count++;
         }
     }
     


### PR DESCRIPTION
closes #26

# 개발 내용

## 기본 빌드 경고 기준 강화
- 기본 `CFLAGS`에 `-Wall -Wextra`를 추가
- 별도 수동 옵션 없이 `make rebuild`만으로 현재 커널 소스의 warning-clean 여부를 확인할 수 있게 정리

## 기존 경고 정리
- framebuffer 문자 렌더링의 glyph 범위 체크를 `FONT8X16_COUNT` 기준으로 정리
- `video_scroll_up`의 미사용 `chars_per_line` 제거
- VMM identity mapping 루프의 미사용 `mapped_count` 제거
- `kmalloc`의 미사용 `old_free_size` 제거

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 scheduler demo 출력 유지 확인
- [x] `git diff --check`
