### PR TITLE
feat: add task blocking runtime

### DIFF
--- a/include/process/scheduler.h
+++ b/include/process/scheduler.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define SCHEDULER_TIMER_HZ 100u
+
 // 스케줄러 초기화
 void scheduler_init(void);
 
@@ -26,6 +28,11 @@ void scheduler_remove_task(task_struct_t* task);
 
 // 스케줄러 통계
 uint32_t scheduler_get_total_tasks(void);
+uint32_t scheduler_get_ticks(void);
+void scheduler_yield_current_task(void);
+void scheduler_sleep_current_task(uint32_t ticks);
+void scheduler_block_current_task(void);
+void scheduler_unblock_task(task_struct_t* task);
 void scheduler_print_status(void);
 void scheduler_reap_terminated_tasks(void);
 

--- a/include/process/task.h
+++ b/include/process/task.h
@@ -25,6 +25,8 @@ typedef struct task_struct {
     uint32_t priority;              // 우선순위 (0이 가장 높음)
     uint32_t time_slice;            // 타임 슬라이스 (틱 수)
     uint32_t time_remaining;        // 남은 타임 슬라이스
+    uint32_t wake_tick;             // sleep 해제 tick
+    bool waiting_for_timer;         // timer sleep queue에 있는지 여부
     
     struct task_struct* next;       // 다음 태스크 (링크드 리스트)
     struct task_struct* prev;       // 이전 태스크
@@ -38,6 +40,11 @@ void task_init(void);
 task_struct_t* task_create(const char* name, void (*entry_point)(void), uint32_t priority);
 void task_destroy(task_struct_t* task);
 void task_exit(void) __attribute__((noreturn));
+void task_yield(void);
+void task_sleep_ticks(uint32_t ticks);
+void task_sleep_ms(uint32_t ms);
+void task_block(void);
+void task_unblock(task_struct_t* task);
 task_struct_t* task_get_current(void);
 void task_set_current(task_struct_t* task);
 uint32_t task_get_next_pid(void);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -11,6 +11,8 @@
 
 #define MB2_MAGIC 0x36d76289
 
+static task_struct_t* scheduler_demo_blocked_task = 0;
+
 static void hlt_loop(void) {
     for(;;) __asm__ __volatile__("hlt");
 }
@@ -41,30 +43,40 @@ static void console_putu32(uint32_t v) {
     }
 }
 
-static void scheduler_demo_delay(void) {
-    for (volatile uint32_t i = 0; i < 3000000; i++) {
-        __asm__ __volatile__("" : : : "memory");
-    }
-}
-
 static void scheduler_demo_task1(void) {
     for (;;) {
         console_putc('1');
-        scheduler_demo_delay();
+
+        if (scheduler_demo_blocked_task &&
+            task_get_state(scheduler_demo_blocked_task) == TASK_BLOCKED &&
+            !scheduler_demo_blocked_task->waiting_for_timer) {
+            task_unblock(scheduler_demo_blocked_task);
+        }
+
+        task_sleep_ticks(20);
     }
 }
 
 static void scheduler_demo_task2(void) {
     for (;;) {
         console_putc('2');
-        scheduler_demo_delay();
+        task_sleep_ms(350);
     }
 }
 
 static void scheduler_demo_task3(void) {
+    uint32_t loops = 0;
+
     for (;;) {
         console_putc('3');
-        scheduler_demo_delay();
+        loops++;
+
+        if ((loops % 4) == 0) {
+            task_block();
+        }
+
+        task_yield();
+        task_sleep_ticks(50);
     }
 }
 
@@ -261,6 +273,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
     task_struct_t* task1 = task_create("task1", scheduler_demo_task1, 1);
     task_struct_t* task2 = task_create("task2", scheduler_demo_task2, 1);
     task_struct_t* task3 = task_create("task3", scheduler_demo_task3, 1);
+    scheduler_demo_blocked_task = task3;
     
     if (task1 && task2 && task3) {
         console_puts("[SCHEDULER] Created 3 tasks successfully\n");
@@ -283,7 +296,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         scheduler_print_status();
         
         console_puts("\n[SCHEDULER] Tasks are ready. Enabling timer IRQ0...\n");
-        console_puts("[SCHEDULER] Output should cycle through 1, 2, and 3.\n");
+        console_puts("[SCHEDULER] Output should show yielding, sleeping, and unblocked tasks.\n");
 
         idt_enable_interrupts();
         kernel_idle_loop();

--- a/src/process/scheduler.c
+++ b/src/process/scheduler.c
@@ -17,12 +17,20 @@ struct interrupt_frame {
 // 라운드 로빈 큐
 static task_struct_t* ready_queue_head = NULL;
 static task_struct_t* ready_queue_tail = NULL;
+static task_struct_t* sleep_queue_head = NULL;
+static task_struct_t* sleep_queue_tail = NULL;
 static task_struct_t* terminated_queue_head = NULL;
 static task_struct_t* terminated_queue_tail = NULL;
 static task_struct_t* current_task = NULL;
 static uint32_t total_tasks = 0;
+static uint32_t sleeping_tasks = 0;
+static uint32_t blocked_tasks = 0;
 static uint32_t terminated_tasks = 0;
 static uint32_t scheduler_ticks = 0;
+
+static bool scheduler_tick_reached(uint32_t now, uint32_t target) {
+    return (int32_t)(now - target) >= 0;
+}
 
 static void scheduler_enqueue_task(task_struct_t* task) {
     task->next = NULL;
@@ -59,6 +67,69 @@ static task_struct_t* scheduler_dequeue_task(void) {
     }
 
     return task;
+}
+
+static void scheduler_enqueue_sleeping_task(task_struct_t* task) {
+    if (!task || task->pid == 0 || task->waiting_for_timer) {
+        return;
+    }
+
+    task->next = NULL;
+    task->prev = sleep_queue_tail;
+    task->waiting_for_timer = true;
+
+    if (sleep_queue_tail) {
+        sleep_queue_tail->next = task;
+    } else {
+        sleep_queue_head = task;
+    }
+
+    sleep_queue_tail = task;
+    sleeping_tasks++;
+}
+
+static void scheduler_remove_sleeping_task(task_struct_t* task) {
+    if (!task || !task->waiting_for_timer) {
+        return;
+    }
+
+    if (task->prev) {
+        task->prev->next = task->next;
+    } else {
+        sleep_queue_head = task->next;
+    }
+
+    if (task->next) {
+        task->next->prev = task->prev;
+    } else {
+        sleep_queue_tail = task->prev;
+    }
+
+    task->next = NULL;
+    task->prev = NULL;
+    task->waiting_for_timer = false;
+    task->wake_tick = 0;
+
+    if (sleeping_tasks > 0) {
+        sleeping_tasks--;
+    }
+}
+
+static void scheduler_wake_sleeping_tasks(void) {
+    task_struct_t* task = sleep_queue_head;
+
+    while (task) {
+        task_struct_t* next = task->next;
+
+        if (scheduler_tick_reached(scheduler_ticks, task->wake_tick)) {
+            scheduler_remove_sleeping_task(task);
+            task->state = TASK_READY;
+            task->time_remaining = task->time_slice;
+            scheduler_enqueue_task(task);
+        }
+
+        task = next;
+    }
 }
 
 static void scheduler_enqueue_terminated_task(task_struct_t* task) {
@@ -107,9 +178,13 @@ void scheduler_init(void) {
     
     ready_queue_head = NULL;
     ready_queue_tail = NULL;
+    sleep_queue_head = NULL;
+    sleep_queue_tail = NULL;
     terminated_queue_head = NULL;
     terminated_queue_tail = NULL;
     total_tasks = 0;
+    sleeping_tasks = 0;
+    blocked_tasks = 0;
     terminated_tasks = 0;
     scheduler_ticks = 0;
     
@@ -202,6 +277,73 @@ uint32_t scheduler_get_total_tasks(void) {
     return total_tasks;
 }
 
+uint32_t scheduler_get_ticks(void) {
+    return scheduler_ticks;
+}
+
+void scheduler_yield_current_task(void) {
+    idt_disable_interrupts();
+
+    if (current_task && current_task->pid != 0 && current_task->state == TASK_RUNNING) {
+        current_task->time_remaining = 0;
+    }
+
+    idt_enable_interrupts();
+}
+
+void scheduler_sleep_current_task(uint32_t ticks) {
+    if (ticks == 0) {
+        scheduler_yield_current_task();
+        return;
+    }
+
+    idt_disable_interrupts();
+
+    if (current_task && current_task->pid != 0 && current_task->state == TASK_RUNNING) {
+        current_task->state = TASK_BLOCKED;
+        current_task->wake_tick = scheduler_ticks + ticks;
+        current_task->time_remaining = 0;
+        scheduler_enqueue_sleeping_task(current_task);
+    }
+
+    idt_enable_interrupts();
+}
+
+void scheduler_block_current_task(void) {
+    idt_disable_interrupts();
+
+    if (current_task && current_task->pid != 0 && current_task->state == TASK_RUNNING) {
+        current_task->state = TASK_BLOCKED;
+        current_task->wake_tick = 0;
+        current_task->time_remaining = 0;
+        blocked_tasks++;
+    }
+
+    idt_enable_interrupts();
+}
+
+void scheduler_unblock_task(task_struct_t* task) {
+    if (!task || task->pid == 0) {
+        return;
+    }
+
+    idt_disable_interrupts();
+
+    if (task->state == TASK_BLOCKED) {
+        if (task->waiting_for_timer) {
+            scheduler_remove_sleeping_task(task);
+        } else if (blocked_tasks > 0) {
+            blocked_tasks--;
+        }
+
+        task->state = TASK_READY;
+        task->time_remaining = task->time_slice;
+        scheduler_enqueue_task(task);
+    }
+
+    idt_enable_interrupts();
+}
+
 void scheduler_reap_terminated_tasks(void) {
     for (;;) {
         idt_disable_interrupts();
@@ -270,6 +412,34 @@ void scheduler_print_status(void) {
     }
     console_puts("\n");
 
+    console_puts("  Sleeping tasks: ");
+    count = sleeping_tasks;
+    idx = 0;
+    if (count == 0) {
+        console_putc('0');
+    } else {
+        while (count > 0 && idx < 11) {
+            buf[idx++] = (char)('0' + (count % 10));
+            count /= 10;
+        }
+        while (idx--) console_putc(buf[idx]);
+    }
+    console_puts("\n");
+
+    console_puts("  Blocked tasks: ");
+    count = blocked_tasks;
+    idx = 0;
+    if (count == 0) {
+        console_putc('0');
+    } else {
+        while (count > 0 && idx < 11) {
+            buf[idx++] = (char)('0' + (count % 10));
+            count /= 10;
+        }
+        while (idx--) console_putc(buf[idx]);
+    }
+    console_puts("\n");
+
     console_puts("  Terminated tasks pending cleanup: ");
     count = terminated_tasks;
     idx = 0;
@@ -326,7 +496,13 @@ uint32_t scheduler_irq_handler(void* frame_ptr) {
     }
     
     // 타임 슬라이스 감소
-    if (current_task->time_remaining > 0) {
+    scheduler_wake_sleeping_tasks();
+
+    if (current_task->pid == 0 && ready_queue_head) {
+        current_task->time_remaining = 0;
+    }
+
+    if (current_task->state == TASK_RUNNING && current_task->time_remaining > 0) {
         current_task->time_remaining--;
     }
     

--- a/src/process/task.c
+++ b/src/process/task.c
@@ -1,4 +1,5 @@
 #include "process/task.h"
+#include "process/scheduler.h"
 #include "mem/kmalloc.h"
 #include "mem/vmm.h"
 #include "drivers/console/console.h"
@@ -10,11 +11,22 @@ static uint32_t next_pid = 1;
 // 커널 태스크 (idle task)
 static task_struct_t kernel_task;
 
-// current_task는 scheduler.c에서 관리
-extern task_struct_t* scheduler_get_current_task(void);
-extern void scheduler_set_current_task(task_struct_t* task);
-
 static void task_entry_trampoline(void) __attribute__((noreturn));
+
+static void task_wait_until_running(void) {
+    task_struct_t* task = scheduler_get_current_task();
+    if (!task || task->pid == 0) {
+        return;
+    }
+
+    for (;;) {
+        __asm__ __volatile__("sti; hlt");
+
+        if (scheduler_get_current_task() == task && task->state == TASK_RUNNING) {
+            return;
+        }
+    }
+}
 
 static void task_entry_trampoline(void) {
     task_struct_t* current = scheduler_get_current_task();
@@ -49,6 +61,8 @@ void task_init(void) {
     kernel_task.priority = 0;
     kernel_task.time_slice = 10;
     kernel_task.time_remaining = 10;
+    kernel_task.wake_tick = 0;
+    kernel_task.waiting_for_timer = false;
     kernel_task.next = NULL;
     kernel_task.prev = NULL;
     kernel_task.creation_time = 0;
@@ -61,6 +75,48 @@ void task_init(void) {
 
 uint32_t task_get_next_pid(void) {
     return next_pid++;
+}
+
+void task_yield(void) {
+    scheduler_yield_current_task();
+    task_wait_until_running();
+}
+
+void task_sleep_ticks(uint32_t ticks) {
+    if (ticks == 0) {
+        task_yield();
+        return;
+    }
+
+    scheduler_sleep_current_task(ticks);
+    task_wait_until_running();
+}
+
+void task_sleep_ms(uint32_t ms) {
+    if (ms == 0) {
+        task_yield();
+        return;
+    }
+
+    uint32_t seconds = ms / 1000;
+    uint32_t remainder = ms % 1000;
+    uint32_t ticks = seconds * SCHEDULER_TIMER_HZ;
+    ticks += (remainder * SCHEDULER_TIMER_HZ + 999) / 1000;
+
+    if (ticks == 0) {
+        ticks = 1;
+    }
+
+    task_sleep_ticks(ticks);
+}
+
+void task_block(void) {
+    scheduler_block_current_task();
+    task_wait_until_running();
+}
+
+void task_unblock(task_struct_t* task) {
+    scheduler_unblock_task(task);
 }
 
 void task_exit(void) {
@@ -99,6 +155,8 @@ task_struct_t* task_create(const char* name, void (*entry_point)(void), uint32_t
     task->priority = priority;
     task->time_slice = 10;  // 기본 타임 슬라이스
     task->time_remaining = task->time_slice;
+    task->wake_tick = 0;
+    task->waiting_for_timer = false;
     task->creation_time = 0;  // TODO: 타이머 구현 후 실제 시간 설정
     task->cpu_time = 0;
     task->entry_point = entry_point;
@@ -233,11 +291,6 @@ void task_set_state(task_struct_t* task, task_state_t state) {
 task_state_t task_get_state(task_struct_t* task) {
     return task ? task->state : TASK_TERMINATED;
 }
-
-// Ready queue 관리는 scheduler.c로 이동
-// 이 함수들은 scheduler 함수를 호출하도록 변경
-extern void scheduler_add_task(task_struct_t* task);
-extern void scheduler_remove_task(task_struct_t* task);
 
 void task_add_to_ready_queue(task_struct_t* task) {
     scheduler_add_task(task);


### PR DESCRIPTION
closes #28

# 개발 내용

## Task runtime API 추가
- `task_yield()` 추가
- `task_sleep_ticks()` / `task_sleep_ms()` 추가
- `task_block()` / `task_unblock()` 추가
- `task_struct_t`에 timer sleep용 `wake_tick`, `waiting_for_timer` 상태 추가

## Scheduler blocking 흐름 추가
- timer sleep queue 추가
- PIT tick마다 wake 시점이 된 task를 ready queue로 복귀
- 현재 task가 sleep/block/yield로 양보하면 다음 timer IRQ에서 안전하게 전환
- idle kernel task 실행 중 ready task가 생기면 바로 스케줄링되도록 처리
- scheduler status에 sleeping/blocked task count 출력

## Demo 갱신
- busy-loop delay 기반 `1/2/3` 출력 제거
- task들이 `yield`, `sleep`, `block/unblock`을 실제로 지나가도록 scheduler demo 갱신

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 yielding/sleeping/unblocked task 출력 유지 확인
- [x] `git diff --check`
