### PR TITLE
feat: add local channel ipc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ VMM_FLUSH_SRC = src/arch/x86/vmm_flush.asm
 KMALLOC_SRC = src/mem/kmalloc.c
 TASK_SRC = src/process/task.c
 SCHEDULER_SRC = src/process/scheduler.c
+CHANNEL_SRC = src/process/channel.c
 CONTEXT_SWITCH_SRC = src/arch/x86/context_switch.asm
 
 # Object files
@@ -58,10 +59,11 @@ VMM_FLUSH_OBJ = $(BUILD_DIR)/vmm_flush.o
 KMALLOC_OBJ = $(BUILD_DIR)/kmalloc.o
 TASK_OBJ = $(BUILD_DIR)/task.o
 SCHEDULER_OBJ = $(BUILD_DIR)/scheduler.o
+CHANNEL_OBJ = $(BUILD_DIR)/channel.o
 CONTEXT_SWITCH_OBJ = $(BUILD_DIR)/context_switch.o
 
 # All object files
-OBJS = $(BOOT_OBJ) $(KERNEL_OBJ) $(VIDEO_OBJ) $(FONT_OBJ) $(CONSOLE_OBJ) $(GDT_OBJ) $(GDT_FLUSH_OBJ) $(IDT_OBJ) $(IDT_FLUSH_OBJ) $(ISR_OBJ) $(IRQ_OBJ) $(MMAP_OBJ) $(PMM_OBJ) $(VMM_OBJ) $(VMM_FLUSH_OBJ) $(KMALLOC_OBJ) $(TASK_OBJ) $(SCHEDULER_OBJ) $(CONTEXT_SWITCH_OBJ)
+OBJS = $(BOOT_OBJ) $(KERNEL_OBJ) $(VIDEO_OBJ) $(FONT_OBJ) $(CONSOLE_OBJ) $(GDT_OBJ) $(GDT_FLUSH_OBJ) $(IDT_OBJ) $(IDT_FLUSH_OBJ) $(ISR_OBJ) $(IRQ_OBJ) $(MMAP_OBJ) $(PMM_OBJ) $(VMM_OBJ) $(VMM_FLUSH_OBJ) $(KMALLOC_OBJ) $(TASK_OBJ) $(SCHEDULER_OBJ) $(CHANNEL_OBJ) $(CONTEXT_SWITCH_OBJ)
 
 # Output files
 KERNEL_ELF = $(BUILD_DIR)/kernel.elf
@@ -204,6 +206,12 @@ $(SCHEDULER_OBJ): $(SCHEDULER_SRC)
 	@mkdir -p $(BUILD_DIR)
 	@echo "Compiling SCHEDULER..."
 	$(CC) $(CFLAGS) -c $(SCHEDULER_SRC) -o $(SCHEDULER_OBJ)
+
+# Compile CHANNEL
+$(CHANNEL_OBJ): $(CHANNEL_SRC)
+	@mkdir -p $(BUILD_DIR)
+	@echo "Compiling CHANNEL..."
+	$(CC) $(CFLAGS) -c $(CHANNEL_SRC) -o $(CHANNEL_OBJ)
 
 # Compile Context Switch (assembly)
 $(CONTEXT_SWITCH_OBJ): $(CONTEXT_SWITCH_SRC)

--- a/include/process/channel.h
+++ b/include/process/channel.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "process/task.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHANNEL_QUEUE_CAPACITY 16u
+
+typedef struct channel channel_t;
+
+typedef struct channel_message {
+    uint32_t type;
+    uint32_t sender_pid;
+    uint32_t value;
+} channel_message_t;
+
+void channel_init(void);
+channel_t* channel_create(void);
+bool channel_send(channel_t* channel, const channel_message_t* message);
+bool channel_recv(channel_t* channel, channel_message_t* out_message);
+uint32_t channel_get_id(const channel_t* channel);
+uint32_t channel_get_owner_pid(const channel_t* channel);
+uint32_t channel_get_count(const channel_t* channel);
+task_struct_t* channel_get_waiting_receiver(const channel_t* channel);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -6,12 +6,14 @@
 #include "mem/kmalloc.h"
 #include "process/task.h"
 #include "process/scheduler.h"
+#include "process/channel.h"
 #include "arch/x86/gdt.h"
 #include "arch/x86/idt.h"
 
 #define MB2_MAGIC 0x36d76289
 
-static task_struct_t* scheduler_demo_blocked_task = 0;
+static channel_t* ipc_request_channel = 0;
+static channel_t* ipc_ack_channel = 0;
 
 static void hlt_loop(void) {
     for(;;) __asm__ __volatile__("hlt");
@@ -43,39 +45,62 @@ static void console_putu32(uint32_t v) {
     }
 }
 
-static void scheduler_demo_task1(void) {
-    for (;;) {
-        console_putc('1');
+static uint32_t current_task_pid(void) {
+    task_struct_t* current = task_get_current();
+    return current ? current->pid : 0;
+}
 
-        if (scheduler_demo_blocked_task &&
-            task_get_state(scheduler_demo_blocked_task) == TASK_BLOCKED &&
-            !scheduler_demo_blocked_task->waiting_for_timer) {
-            task_unblock(scheduler_demo_blocked_task);
+static void channel_producer_task(void) {
+    uint32_t value = 0;
+
+    for (;;) {
+        value++;
+
+        channel_message_t request = {
+            .type = 1,
+            .sender_pid = current_task_pid(),
+            .value = value,
+        };
+
+        if (channel_send(ipc_request_channel, &request)) {
+            console_putc('S');
+
+            channel_message_t ack;
+            if (channel_recv(ipc_ack_channel, &ack)) {
+                console_putc('A');
+            }
+        } else {
+            console_putc('!');
         }
 
-        task_sleep_ticks(20);
+        task_sleep_ticks(25);
     }
 }
 
-static void scheduler_demo_task2(void) {
+static void channel_consumer_task(void) {
     for (;;) {
-        console_putc('2');
-        task_sleep_ms(350);
+        channel_message_t request;
+
+        if (channel_recv(ipc_request_channel, &request)) {
+            console_putc('R');
+            console_putc((char)('0' + (request.value % 10)));
+
+            channel_message_t ack = {
+                .type = 2,
+                .sender_pid = current_task_pid(),
+                .value = request.value,
+            };
+
+            channel_send(ipc_ack_channel, &ack);
+        } else {
+            task_yield();
+        }
     }
 }
 
-static void scheduler_demo_task3(void) {
-    uint32_t loops = 0;
-
+static void channel_heartbeat_task(void) {
     for (;;) {
-        console_putc('3');
-        loops++;
-
-        if ((loops % 4) == 0) {
-            task_block();
-        }
-
-        task_yield();
+        console_putc('.');
         task_sleep_ticks(50);
     }
 }
@@ -266,37 +291,54 @@ void kernel_main(uint32_t magic, void* mbinfo) {
     // Initialize Scheduler
     console_puts("\n[SCHEDULER] Initializing scheduler...\n");
     scheduler_init();
+
+    // Initialize local Channel IPC
+    console_puts("\n[CHANNEL] Initializing local IPC...\n");
+    channel_init();
+
+    ipc_request_channel = channel_create();
+    ipc_ack_channel = channel_create();
+
+    if (!ipc_request_channel || !ipc_ack_channel) {
+        console_puts("[CHANNEL] Failed to create IPC demo channels\n");
+        hlt_loop();
+    }
+
+    console_puts("[CHANNEL] Created request channel #");
+    console_putu32(channel_get_id(ipc_request_channel));
+    console_puts(" and ack channel #");
+    console_putu32(channel_get_id(ipc_ack_channel));
+    console_puts("\n");
     
-    // Test: Task 생성 및 스케줄링
-    console_puts("[SCHEDULER] Starting round-robin scheduler demo...\n");
+    // Test: Task scheduling and local Channel IPC
+    console_puts("[CHANNEL] Starting producer/consumer IPC demo...\n");
     
-    task_struct_t* task1 = task_create("task1", scheduler_demo_task1, 1);
-    task_struct_t* task2 = task_create("task2", scheduler_demo_task2, 1);
-    task_struct_t* task3 = task_create("task3", scheduler_demo_task3, 1);
-    scheduler_demo_blocked_task = task3;
+    task_struct_t* producer = task_create("producer", channel_producer_task, 1);
+    task_struct_t* consumer = task_create("consumer", channel_consumer_task, 1);
+    task_struct_t* heartbeat = task_create("heartbeat", channel_heartbeat_task, 1);
     
-    if (task1 && task2 && task3) {
+    if (producer && consumer && heartbeat) {
         console_puts("[SCHEDULER] Created 3 tasks successfully\n");
         
         // 태스크 정보 출력
         console_puts("\n[SCHEDULER] Task information:\n");
         task_print_info(scheduler_get_current_task());
-        task_print_info(task1);
-        task_print_info(task2);
-        task_print_info(task3);
+        task_print_info(producer);
+        task_print_info(consumer);
+        task_print_info(heartbeat);
         
         // 스케줄러에 추가
         console_puts("\n[SCHEDULER] Adding tasks to scheduler...\n");
-        scheduler_add_task(task1);
-        scheduler_add_task(task2);
-        scheduler_add_task(task3);
+        scheduler_add_task(producer);
+        scheduler_add_task(consumer);
+        scheduler_add_task(heartbeat);
         
         // 스케줄러 상태 출력
         console_puts("\n");
         scheduler_print_status();
         
         console_puts("\n[SCHEDULER] Tasks are ready. Enabling timer IRQ0...\n");
-        console_puts("[SCHEDULER] Output should show yielding, sleeping, and unblocked tasks.\n");
+        console_puts("[CHANNEL] Output should show send(S), receive(Rn), ack(A), and heartbeat(.).\n");
 
         idt_enable_interrupts();
         kernel_idle_loop();

--- a/src/process/channel.c
+++ b/src/process/channel.c
@@ -1,0 +1,169 @@
+#include "process/channel.h"
+#include "process/scheduler.h"
+#include "arch/x86/idt.h"
+#include "mem/kmalloc.h"
+#include <stddef.h>
+
+struct channel {
+    uint32_t id;
+    uint32_t owner_pid;
+    channel_message_t queue[CHANNEL_QUEUE_CAPACITY];
+    uint32_t head;
+    uint32_t tail;
+    uint32_t count;
+    task_struct_t* waiting_receiver;
+    struct channel* next;
+};
+
+static channel_t* channel_list = NULL;
+static uint32_t next_channel_id = 1;
+
+static bool channel_interrupts_enabled(void) {
+    uint32_t flags;
+    __asm__ __volatile__("pushf; pop %0" : "=r"(flags));
+    return (flags & 0x200) != 0;
+}
+
+static void channel_restore_interrupts(bool enabled) {
+    if (enabled) {
+        idt_enable_interrupts();
+    }
+}
+
+static void channel_wait_until_running(task_struct_t* task) {
+    if (!task || task->pid == 0) {
+        return;
+    }
+
+    for (;;) {
+        __asm__ __volatile__("sti; hlt");
+
+        if (scheduler_get_current_task() == task && task->state == TASK_RUNNING) {
+            return;
+        }
+    }
+}
+
+static bool channel_enqueue(channel_t* channel, const channel_message_t* message) {
+    if (channel->count >= CHANNEL_QUEUE_CAPACITY) {
+        return false;
+    }
+
+    channel->queue[channel->tail] = *message;
+    channel->tail = (channel->tail + 1) % CHANNEL_QUEUE_CAPACITY;
+    channel->count++;
+    return true;
+}
+
+static bool channel_dequeue(channel_t* channel, channel_message_t* out_message) {
+    if (channel->count == 0) {
+        return false;
+    }
+
+    *out_message = channel->queue[channel->head];
+    channel->head = (channel->head + 1) % CHANNEL_QUEUE_CAPACITY;
+    channel->count--;
+    return true;
+}
+
+void channel_init(void) {
+    channel_list = NULL;
+    next_channel_id = 1;
+}
+
+channel_t* channel_create(void) {
+    channel_t* channel = (channel_t*)kmalloc(sizeof(channel_t));
+    if (!channel) {
+        return NULL;
+    }
+
+    task_struct_t* owner = scheduler_get_current_task();
+
+    channel->owner_pid = owner ? owner->pid : 0;
+    channel->head = 0;
+    channel->tail = 0;
+    channel->count = 0;
+    channel->waiting_receiver = NULL;
+
+    bool interrupts_enabled = channel_interrupts_enabled();
+    idt_disable_interrupts();
+    channel->id = next_channel_id++;
+    channel->next = channel_list;
+    channel_list = channel;
+    channel_restore_interrupts(interrupts_enabled);
+
+    return channel;
+}
+
+bool channel_send(channel_t* channel, const channel_message_t* message) {
+    if (!channel || !message) {
+        return false;
+    }
+
+    bool interrupts_enabled = channel_interrupts_enabled();
+    idt_disable_interrupts();
+
+    bool sent = channel_enqueue(channel, message);
+    task_struct_t* receiver = NULL;
+
+    if (sent && channel->waiting_receiver) {
+        receiver = channel->waiting_receiver;
+        channel->waiting_receiver = NULL;
+    }
+
+    channel_restore_interrupts(interrupts_enabled);
+
+    if (receiver) {
+        task_unblock(receiver);
+    }
+
+    return sent;
+}
+
+bool channel_recv(channel_t* channel, channel_message_t* out_message) {
+    if (!channel || !out_message) {
+        return false;
+    }
+
+    task_struct_t* current = scheduler_get_current_task();
+    if (!current || current->pid == 0) {
+        return false;
+    }
+
+    for (;;) {
+        bool interrupts_enabled = channel_interrupts_enabled();
+        idt_disable_interrupts();
+
+        if (channel_dequeue(channel, out_message)) {
+            channel_restore_interrupts(interrupts_enabled);
+            return true;
+        }
+
+        if (channel->waiting_receiver && channel->waiting_receiver != current) {
+            channel_restore_interrupts(interrupts_enabled);
+            task_yield();
+            continue;
+        }
+
+        channel->waiting_receiver = current;
+        scheduler_block_current_task();
+
+        channel_wait_until_running(current);
+    }
+}
+
+uint32_t channel_get_id(const channel_t* channel) {
+    return channel ? channel->id : 0;
+}
+
+uint32_t channel_get_owner_pid(const channel_t* channel) {
+    return channel ? channel->owner_pid : 0;
+}
+
+uint32_t channel_get_count(const channel_t* channel) {
+    return channel ? channel->count : 0;
+}
+
+task_struct_t* channel_get_waiting_receiver(const channel_t* channel) {
+    return channel ? channel->waiting_receiver : NULL;
+}


### PR DESCRIPTION
closes #30

# 개발 내용

## Local Channel IPC 추가
- `channel_create()`로 여러 kernel-managed channel 생성 가능
- 고정 크기 `channel_message_t`와 ring buffer 기반 message queue 추가
- `channel_send()` / `channel_recv()` API 추가
- channel별 id, owner pid, queued message count, waiting receiver 조회 API 추가

## Blocking receive 흐름 추가
- message가 없는 channel에서 `channel_recv()`를 호출하면 현재 task를 block
- `channel_send()`가 message를 enqueue하면 waiting receiver를 unblock
- recv task가 다시 실행되면 queue에서 message를 읽고 계속 진행
- channel 임계구역에서 기존 interrupt enable 상태를 보존하도록 처리

## Producer/Consumer demo 갱신
- request channel과 ack channel 두 개를 생성해 multi-channel 구조 확인
- producer task가 request를 보내고 ack channel에서 응답 대기
- consumer task가 request를 recv하고 ack를 send
- heartbeat task로 scheduler가 계속 살아 있음을 화면에서 확인

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 `S`, `Rn`, `A`, `.` IPC demo 출력 확인
- [x] `git diff --check`
