### PR TITLE
feat: add channel receiver wait queue

### DIFF
--- a/include/process/channel.h
+++ b/include/process/channel.h
@@ -21,4 +21,5 @@ bool channel_recv(channel_t* channel, channel_message_t* out_message);
 uint32_t channel_get_id(const channel_t* channel);
 uint32_t channel_get_owner_pid(const channel_t* channel);
 uint32_t channel_get_count(const channel_t* channel);
-task_struct_t* channel_get_waiting_receiver(const channel_t* channel);
+uint32_t channel_get_waiting_receiver_count(const channel_t* channel);
+task_struct_t* channel_peek_waiting_receiver(const channel_t* channel);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -67,7 +67,7 @@ static void channel_producer_task(void) {
 
             channel_message_t ack;
             if (channel_recv(ipc_ack_channel, &ack)) {
-                console_putc('A');
+                console_putc('K');
             }
         } else {
             console_putc('!');
@@ -77,12 +77,12 @@ static void channel_producer_task(void) {
     }
 }
 
-static void channel_consumer_task(void) {
+static void channel_consumer_loop(char label) {
     for (;;) {
         channel_message_t request;
 
         if (channel_recv(ipc_request_channel, &request)) {
-            console_putc('R');
+            console_putc(label);
             console_putc((char)('0' + (request.value % 10)));
 
             channel_message_t ack = {
@@ -96,6 +96,14 @@ static void channel_consumer_task(void) {
             task_yield();
         }
     }
+}
+
+static void channel_consumer_a_task(void) {
+    channel_consumer_loop('a');
+}
+
+static void channel_consumer_b_task(void) {
+    channel_consumer_loop('b');
 }
 
 static void channel_heartbeat_task(void) {
@@ -314,23 +322,26 @@ void kernel_main(uint32_t magic, void* mbinfo) {
     console_puts("[CHANNEL] Starting producer/consumer IPC demo...\n");
     
     task_struct_t* producer = task_create("producer", channel_producer_task, 1);
-    task_struct_t* consumer = task_create("consumer", channel_consumer_task, 1);
+    task_struct_t* consumer_a = task_create("consumerA", channel_consumer_a_task, 1);
+    task_struct_t* consumer_b = task_create("consumerB", channel_consumer_b_task, 1);
     task_struct_t* heartbeat = task_create("heartbeat", channel_heartbeat_task, 1);
     
-    if (producer && consumer && heartbeat) {
-        console_puts("[SCHEDULER] Created 3 tasks successfully\n");
+    if (producer && consumer_a && consumer_b && heartbeat) {
+        console_puts("[SCHEDULER] Created 4 tasks successfully\n");
         
         // 태스크 정보 출력
         console_puts("\n[SCHEDULER] Task information:\n");
         task_print_info(scheduler_get_current_task());
         task_print_info(producer);
-        task_print_info(consumer);
+        task_print_info(consumer_a);
+        task_print_info(consumer_b);
         task_print_info(heartbeat);
         
         // 스케줄러에 추가
         console_puts("\n[SCHEDULER] Adding tasks to scheduler...\n");
         scheduler_add_task(producer);
-        scheduler_add_task(consumer);
+        scheduler_add_task(consumer_a);
+        scheduler_add_task(consumer_b);
         scheduler_add_task(heartbeat);
         
         // 스케줄러 상태 출력
@@ -338,7 +349,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         scheduler_print_status();
         
         console_puts("\n[SCHEDULER] Tasks are ready. Enabling timer IRQ0...\n");
-        console_puts("[CHANNEL] Output should show send(S), receive(Rn), ack(A), and heartbeat(.).\n");
+        console_puts("[CHANNEL] Output should show send(S), consumer(a/b), ack(K), and heartbeat(.).\n");
 
         idt_enable_interrupts();
         kernel_idle_loop();

--- a/src/process/channel.c
+++ b/src/process/channel.c
@@ -11,7 +11,9 @@ struct channel {
     uint32_t head;
     uint32_t tail;
     uint32_t count;
-    task_struct_t* waiting_receiver;
+    task_struct_t* receiver_wait_head;
+    task_struct_t* receiver_wait_tail;
+    uint32_t receiver_wait_count;
     struct channel* next;
 };
 
@@ -66,6 +68,61 @@ static bool channel_dequeue(channel_t* channel, channel_message_t* out_message) 
     return true;
 }
 
+static bool channel_receiver_is_waiting(const channel_t* channel, const task_struct_t* task) {
+    task_struct_t* current = channel->receiver_wait_head;
+
+    while (current) {
+        if (current == task) {
+            return true;
+        }
+
+        current = current->next;
+    }
+
+    return false;
+}
+
+static void channel_enqueue_receiver(channel_t* channel, task_struct_t* task) {
+    if (channel_receiver_is_waiting(channel, task)) {
+        return;
+    }
+
+    task->next = NULL;
+    task->prev = channel->receiver_wait_tail;
+
+    if (channel->receiver_wait_tail) {
+        channel->receiver_wait_tail->next = task;
+    } else {
+        channel->receiver_wait_head = task;
+    }
+
+    channel->receiver_wait_tail = task;
+    channel->receiver_wait_count++;
+}
+
+static task_struct_t* channel_dequeue_receiver(channel_t* channel) {
+    task_struct_t* task = channel->receiver_wait_head;
+    if (!task) {
+        return NULL;
+    }
+
+    channel->receiver_wait_head = task->next;
+    if (channel->receiver_wait_head) {
+        channel->receiver_wait_head->prev = NULL;
+    } else {
+        channel->receiver_wait_tail = NULL;
+    }
+
+    task->next = NULL;
+    task->prev = NULL;
+
+    if (channel->receiver_wait_count > 0) {
+        channel->receiver_wait_count--;
+    }
+
+    return task;
+}
+
 void channel_init(void) {
     channel_list = NULL;
     next_channel_id = 1;
@@ -83,7 +140,9 @@ channel_t* channel_create(void) {
     channel->head = 0;
     channel->tail = 0;
     channel->count = 0;
-    channel->waiting_receiver = NULL;
+    channel->receiver_wait_head = NULL;
+    channel->receiver_wait_tail = NULL;
+    channel->receiver_wait_count = 0;
 
     bool interrupts_enabled = channel_interrupts_enabled();
     idt_disable_interrupts();
@@ -106,9 +165,8 @@ bool channel_send(channel_t* channel, const channel_message_t* message) {
     bool sent = channel_enqueue(channel, message);
     task_struct_t* receiver = NULL;
 
-    if (sent && channel->waiting_receiver) {
-        receiver = channel->waiting_receiver;
-        channel->waiting_receiver = NULL;
+    if (sent) {
+        receiver = channel_dequeue_receiver(channel);
     }
 
     channel_restore_interrupts(interrupts_enabled);
@@ -139,13 +197,7 @@ bool channel_recv(channel_t* channel, channel_message_t* out_message) {
             return true;
         }
 
-        if (channel->waiting_receiver && channel->waiting_receiver != current) {
-            channel_restore_interrupts(interrupts_enabled);
-            task_yield();
-            continue;
-        }
-
-        channel->waiting_receiver = current;
+        channel_enqueue_receiver(channel, current);
         scheduler_block_current_task();
 
         channel_wait_until_running(current);
@@ -164,6 +216,10 @@ uint32_t channel_get_count(const channel_t* channel) {
     return channel ? channel->count : 0;
 }
 
-task_struct_t* channel_get_waiting_receiver(const channel_t* channel) {
-    return channel ? channel->waiting_receiver : NULL;
+uint32_t channel_get_waiting_receiver_count(const channel_t* channel) {
+    return channel ? channel->receiver_wait_count : 0;
+}
+
+task_struct_t* channel_peek_waiting_receiver(const channel_t* channel) {
+    return channel ? channel->receiver_wait_head : NULL;
 }


### PR DESCRIPTION
closes #32

# 개발 내용

## Channel receiver wait queue 추가
- channel별 단일 `waiting_receiver`를 FIFO receiver wait queue로 확장
- 빈 channel에서 여러 task가 `channel_recv()`로 block될 수 있도록 처리
- `channel_send()`가 message를 enqueue하면 가장 먼저 기다린 receiver 하나를 unblock
- receiver wait queue count와 head receiver 조회 API 추가

## Multi-consumer demo 갱신
- request channel을 공유하는 `consumerA`, `consumerB` task 추가
- producer가 request를 send하고 ack channel에서 응답을 기다리는 흐름 유지
- 화면 출력에서 `S`, `a/b`, `K`, `.` 패턴으로 send, consumer 분배, ack, heartbeat 확인

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 `consumerA`, `consumerB`, `Sa...K`, `Sb...K`, `.` 출력 확인
- [x] `git diff --check`
