### PR TITLE
feat: add channel sender wait queue

### DIFF
--- a/include/process/channel.h
+++ b/include/process/channel.h
@@ -23,3 +23,5 @@ uint32_t channel_get_owner_pid(const channel_t* channel);
 uint32_t channel_get_count(const channel_t* channel);
 uint32_t channel_get_waiting_receiver_count(const channel_t* channel);
 task_struct_t* channel_peek_waiting_receiver(const channel_t* channel);
+uint32_t channel_get_waiting_sender_count(const channel_t* channel);
+task_struct_t* channel_peek_waiting_sender(const channel_t* channel);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -11,9 +11,9 @@
 #include "arch/x86/idt.h"
 
 #define MB2_MAGIC 0x36d76289
+#define CHANNEL_BURST_MESSAGES (CHANNEL_QUEUE_CAPACITY + 4u)
 
 static channel_t* ipc_request_channel = 0;
-static channel_t* ipc_ack_channel = 0;
 
 static void hlt_loop(void) {
     for(;;) __asm__ __volatile__("hlt");
@@ -54,26 +54,27 @@ static void channel_producer_task(void) {
     uint32_t value = 0;
 
     for (;;) {
-        value++;
+        for (uint32_t i = 0; i < CHANNEL_BURST_MESSAGES; i++) {
+            value++;
 
-        channel_message_t request = {
-            .type = 1,
-            .sender_pid = current_task_pid(),
-            .value = value,
-        };
+            channel_message_t request = {
+                .type = 1,
+                .sender_pid = current_task_pid(),
+                .value = value,
+            };
 
-        if (channel_send(ipc_request_channel, &request)) {
-            console_putc('S');
-
-            channel_message_t ack;
-            if (channel_recv(ipc_ack_channel, &ack)) {
-                console_putc('K');
+            if (channel_get_count(ipc_request_channel) >= CHANNEL_QUEUE_CAPACITY) {
+                console_putc('W');
             }
-        } else {
-            console_putc('!');
+
+            if (channel_send(ipc_request_channel, &request)) {
+                console_putc('S');
+            } else {
+                console_putc('!');
+            }
         }
 
-        task_sleep_ticks(25);
+        task_sleep_ticks(80);
     }
 }
 
@@ -84,14 +85,7 @@ static void channel_consumer_loop(char label) {
         if (channel_recv(ipc_request_channel, &request)) {
             console_putc(label);
             console_putc((char)('0' + (request.value % 10)));
-
-            channel_message_t ack = {
-                .type = 2,
-                .sender_pid = current_task_pid(),
-                .value = request.value,
-            };
-
-            channel_send(ipc_ack_channel, &ack);
+            task_sleep_ticks(12);
         } else {
             task_yield();
         }
@@ -305,21 +299,17 @@ void kernel_main(uint32_t magic, void* mbinfo) {
     channel_init();
 
     ipc_request_channel = channel_create();
-    ipc_ack_channel = channel_create();
-
-    if (!ipc_request_channel || !ipc_ack_channel) {
+    if (!ipc_request_channel) {
         console_puts("[CHANNEL] Failed to create IPC demo channels\n");
         hlt_loop();
     }
 
     console_puts("[CHANNEL] Created request channel #");
     console_putu32(channel_get_id(ipc_request_channel));
-    console_puts(" and ack channel #");
-    console_putu32(channel_get_id(ipc_ack_channel));
     console_puts("\n");
     
     // Test: Task scheduling and local Channel IPC
-    console_puts("[CHANNEL] Starting producer/consumer IPC demo...\n");
+    console_puts("[CHANNEL] Starting producer/consumer backpressure demo...\n");
     
     task_struct_t* producer = task_create("producer", channel_producer_task, 1);
     task_struct_t* consumer_a = task_create("consumerA", channel_consumer_a_task, 1);
@@ -349,7 +339,7 @@ void kernel_main(uint32_t magic, void* mbinfo) {
         scheduler_print_status();
         
         console_puts("\n[SCHEDULER] Tasks are ready. Enabling timer IRQ0...\n");
-        console_puts("[CHANNEL] Output should show send(S), consumer(a/b), ack(K), and heartbeat(.).\n");
+        console_puts("[CHANNEL] Output should show send(S), wait(W), consumer(a/b), and heartbeat(.).\n");
 
         idt_enable_interrupts();
         kernel_idle_loop();

--- a/src/process/channel.c
+++ b/src/process/channel.c
@@ -4,6 +4,12 @@
 #include "mem/kmalloc.h"
 #include <stddef.h>
 
+typedef struct channel_wait_queue {
+    task_struct_t* head;
+    task_struct_t* tail;
+    uint32_t count;
+} channel_wait_queue_t;
+
 struct channel {
     uint32_t id;
     uint32_t owner_pid;
@@ -11,9 +17,8 @@ struct channel {
     uint32_t head;
     uint32_t tail;
     uint32_t count;
-    task_struct_t* receiver_wait_head;
-    task_struct_t* receiver_wait_tail;
-    uint32_t receiver_wait_count;
+    channel_wait_queue_t receiver_wait_queue;
+    channel_wait_queue_t sender_wait_queue;
     struct channel* next;
 };
 
@@ -68,8 +73,14 @@ static bool channel_dequeue(channel_t* channel, channel_message_t* out_message) 
     return true;
 }
 
-static bool channel_receiver_is_waiting(const channel_t* channel, const task_struct_t* task) {
-    task_struct_t* current = channel->receiver_wait_head;
+static void channel_wait_queue_init(channel_wait_queue_t* queue) {
+    queue->head = NULL;
+    queue->tail = NULL;
+    queue->count = 0;
+}
+
+static bool channel_wait_queue_contains(const channel_wait_queue_t* queue, const task_struct_t* task) {
+    task_struct_t* current = queue->head;
 
     while (current) {
         if (current == task) {
@@ -82,42 +93,42 @@ static bool channel_receiver_is_waiting(const channel_t* channel, const task_str
     return false;
 }
 
-static void channel_enqueue_receiver(channel_t* channel, task_struct_t* task) {
-    if (channel_receiver_is_waiting(channel, task)) {
+static void channel_wait_queue_push(channel_wait_queue_t* queue, task_struct_t* task) {
+    if (channel_wait_queue_contains(queue, task)) {
         return;
     }
 
     task->next = NULL;
-    task->prev = channel->receiver_wait_tail;
+    task->prev = queue->tail;
 
-    if (channel->receiver_wait_tail) {
-        channel->receiver_wait_tail->next = task;
+    if (queue->tail) {
+        queue->tail->next = task;
     } else {
-        channel->receiver_wait_head = task;
+        queue->head = task;
     }
 
-    channel->receiver_wait_tail = task;
-    channel->receiver_wait_count++;
+    queue->tail = task;
+    queue->count++;
 }
 
-static task_struct_t* channel_dequeue_receiver(channel_t* channel) {
-    task_struct_t* task = channel->receiver_wait_head;
+static task_struct_t* channel_wait_queue_pop(channel_wait_queue_t* queue) {
+    task_struct_t* task = queue->head;
     if (!task) {
         return NULL;
     }
 
-    channel->receiver_wait_head = task->next;
-    if (channel->receiver_wait_head) {
-        channel->receiver_wait_head->prev = NULL;
+    queue->head = task->next;
+    if (queue->head) {
+        queue->head->prev = NULL;
     } else {
-        channel->receiver_wait_tail = NULL;
+        queue->tail = NULL;
     }
 
     task->next = NULL;
     task->prev = NULL;
 
-    if (channel->receiver_wait_count > 0) {
-        channel->receiver_wait_count--;
+    if (queue->count > 0) {
+        queue->count--;
     }
 
     return task;
@@ -140,9 +151,8 @@ channel_t* channel_create(void) {
     channel->head = 0;
     channel->tail = 0;
     channel->count = 0;
-    channel->receiver_wait_head = NULL;
-    channel->receiver_wait_tail = NULL;
-    channel->receiver_wait_count = 0;
+    channel_wait_queue_init(&channel->receiver_wait_queue);
+    channel_wait_queue_init(&channel->sender_wait_queue);
 
     bool interrupts_enabled = channel_interrupts_enabled();
     idt_disable_interrupts();
@@ -159,23 +169,34 @@ bool channel_send(channel_t* channel, const channel_message_t* message) {
         return false;
     }
 
-    bool interrupts_enabled = channel_interrupts_enabled();
-    idt_disable_interrupts();
+    task_struct_t* current = scheduler_get_current_task();
 
-    bool sent = channel_enqueue(channel, message);
-    task_struct_t* receiver = NULL;
+    for (;;) {
+        bool interrupts_enabled = channel_interrupts_enabled();
+        idt_disable_interrupts();
 
-    if (sent) {
-        receiver = channel_dequeue_receiver(channel);
+        if (channel_enqueue(channel, message)) {
+            task_struct_t* receiver = channel_wait_queue_pop(&channel->receiver_wait_queue);
+
+            channel_restore_interrupts(interrupts_enabled);
+
+            if (receiver) {
+                task_unblock(receiver);
+            }
+
+            return true;
+        }
+
+        if (!current || current->pid == 0) {
+            channel_restore_interrupts(interrupts_enabled);
+            return false;
+        }
+
+        channel_wait_queue_push(&channel->sender_wait_queue, current);
+        scheduler_block_current_task();
+
+        channel_wait_until_running(current);
     }
-
-    channel_restore_interrupts(interrupts_enabled);
-
-    if (receiver) {
-        task_unblock(receiver);
-    }
-
-    return sent;
 }
 
 bool channel_recv(channel_t* channel, channel_message_t* out_message) {
@@ -193,11 +214,18 @@ bool channel_recv(channel_t* channel, channel_message_t* out_message) {
         idt_disable_interrupts();
 
         if (channel_dequeue(channel, out_message)) {
+            task_struct_t* sender = channel_wait_queue_pop(&channel->sender_wait_queue);
+
             channel_restore_interrupts(interrupts_enabled);
+
+            if (sender) {
+                task_unblock(sender);
+            }
+
             return true;
         }
 
-        channel_enqueue_receiver(channel, current);
+        channel_wait_queue_push(&channel->receiver_wait_queue, current);
         scheduler_block_current_task();
 
         channel_wait_until_running(current);
@@ -217,9 +245,17 @@ uint32_t channel_get_count(const channel_t* channel) {
 }
 
 uint32_t channel_get_waiting_receiver_count(const channel_t* channel) {
-    return channel ? channel->receiver_wait_count : 0;
+    return channel ? channel->receiver_wait_queue.count : 0;
 }
 
 task_struct_t* channel_peek_waiting_receiver(const channel_t* channel) {
-    return channel ? channel->receiver_wait_head : NULL;
+    return channel ? channel->receiver_wait_queue.head : NULL;
+}
+
+uint32_t channel_get_waiting_sender_count(const channel_t* channel) {
+    return channel ? channel->sender_wait_queue.count : 0;
+}
+
+task_struct_t* channel_peek_waiting_sender(const channel_t* channel) {
+    return channel ? channel->sender_wait_queue.head : NULL;
 }


### PR DESCRIPTION
closes #34

# 개발 내용

## Channel sender wait queue 추가
- channel 내부 wait queue를 공통 구조로 정리하고 receiver/sender wait queue를 분리
- channel queue가 가득 찬 상태에서 `channel_send()`를 호출하면 sender task를 block
- `channel_recv()`가 message를 dequeue해서 공간을 만들면 가장 먼저 기다린 sender 하나를 unblock
- sender wait queue count와 head sender 조회 API 추가

## Backpressure demo 갱신
- producer가 channel capacity보다 많은 message를 burst로 send하도록 변경
- consumer는 message를 recv한 뒤 잠깐 sleep해서 channel queue가 가득 차는 상황을 재현
- 화면 출력에서 `S`, `W`, `a/b`, `.` 패턴으로 send, sender wait, consumer 처리, heartbeat 확인

## 테스트
- [x] `make rebuild`
- [x] `x86_64-elf-readelf -l build/kernel.elf`
- [x] QEMU screendump로 `W`, `S`, `a/b`, `.` backpressure demo 출력 확인
- [x] `git diff --check`
